### PR TITLE
Validate SA_HASH_LENGTH environment variable to ensure it is within valid range

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - 'README.md'
   push:
+    branches:
+      - main
     paths-ignore:
       - 'README.md'
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -210,7 +210,7 @@ func (d *providerData) configProviderFromEnvironment() diag.Diagnostics {
 		if i > 0 && i <= math.MaxInt32 {
 			d.HashLength = types.Int32Value(int32(i))
 		} else {
-			diags.AddError("Invalid Environment Variable", fmt.Sprintf("Invalid value for SA_HASH_LENGTH: %s, must be between 1 and %d", val, math.MaxInt32))
+			diags.AddError("Invalid Environment Variable", fmt.Sprintf("Invalid value for SA_HASH_LENGTH: %s (parsed as %d), must be between 1 and %d", val, i, math.MaxInt32))
 			return diags
 		}
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"io/fs"
+	"math"
 	"os"
 	"strconv"
 	s "terraform-provider-standesamt/internal/schema"
@@ -206,7 +207,12 @@ func (d *providerData) configProviderFromEnvironment() diag.Diagnostics {
 			diags.AddError("Invalid Environment Variable", fmt.Sprintf("Invalid value for SA_HASH_LENGTH: %s", err))
 			return diags
 		}
-		d.HashLength = types.Int32Value(int32(i))
+		if i > 0 && i <= math.MaxInt32 {
+			d.HashLength = types.Int32Value(int32(i))
+		} else {
+			diags.AddError("Invalid Environment Variable", fmt.Sprintf("Invalid value for SA_HASH_LENGTH: %s, must be between 1 and %d", val, math.MaxInt32))
+			return diags
+		}
 	}
 
 	if val := os.Getenv("SA_LOWERCASE"); val != "" && d.Lowercase.IsNull() {


### PR DESCRIPTION
This pull request introduces a validation check for the `SA_HASH_LENGTH` environment variable in the `internal/provider/provider.go` file, ensuring its value falls within a valid range. Additionally, the `math` package is imported to facilitate this validation.

### Validation Improvements:

* [`internal/provider/provider.go`](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R210-R215): Added a check to ensure the `SA_HASH_LENGTH` environment variable is within the range of 1 to `math.MaxInt32`. If the value is invalid, an error diagnostic is added and the function exits early.

### Codebase Updates:

* [`internal/provider/provider.go`](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R24): Imported the `math` package to enable range validation for the `SA_HASH_LENGTH` variable.