### PR TITLE
Feature/add validation for double hyphens in name function

### DIFF
--- a/internal/provider/name_function.go
+++ b/internal/provider/name_function.go
@@ -290,7 +290,7 @@ func (f *NameFunction) Run(ctx context.Context, req function.RunRequest, resp *f
 
 	// Check the final name against the naming schema constraints
 	if typeSchema.Configuration.DenyDoubleHyphens.ValueBool() {
-		resp.Error = function.ConcatFuncErrors(resp.Error, validateDoubleHyphens(result.Name.ValueString(), resp))
+		resp.Error = function.ConcatFuncErrors(resp.Error, validateDoubleHyphens(resultNameStr, resp))
 	}
 
 	resp.Error = function.ConcatFuncErrors(resp.Error, validateResult(resultNameStr, typeSchema, resp))

--- a/internal/provider/name_function_test.go
+++ b/internal/provider/name_function_test.go
@@ -54,6 +54,22 @@ func TestNameFunction_DoubleHyphenError(t *testing.T) {
 	})
 }
 
+func TestNameFunction_DoubleHyphenNoError(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesUnique(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf("%s %s", remote_schema_config_with_no_settings, `output "test" {
+					value = provider::standesamt::name(local.config, "azurerm_resource_group", local.settings, "te--st")
+				}`),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test", knownvalue.StringExact("rg-te--st")),
+				},
+			},
+		},
+	})
+}
+
 func TestNameFunction_MinLength(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesUnique(),

--- a/internal/provider/name_function_test.go
+++ b/internal/provider/name_function_test.go
@@ -40,6 +40,20 @@ func TestNameFunction_MaxLength(t *testing.T) {
 	})
 }
 
+func TestNameFunction_DoubleHyphenError(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesUnique(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf("%s %s", default_config_with_no_settings_default_precedence, `output "test" {
+					value = provider::standesamt::name(local.config, "azurerm_resource_group", local.settings, "12345--67890")
+				}`),
+				ExpectError: regexp.MustCompile(`Invalid name: 'rg-12345--67890-we' contains double hyphens`),
+			},
+		},
+	})
+}
+
 func TestNameFunction_MinLength(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesUnique(),
@@ -193,7 +207,7 @@ locals {
 				  use_environment		= true
 				  use_lower_case 		= false
 				  use_separator 		= true
-				  deny_double_hyphens = false
+				  deny_double_hyphens = true
 				  name_precedence		= []
 				  hash_length			= 0
 				}				


### PR DESCRIPTION
This pull request introduces a validation mechanism to prevent double hyphens in names generated by the `NameFunction`. It includes updates to the core logic, validation functions, tests, and configuration defaults to support this feature.

### Validation for double hyphens:
* [`internal/provider/name_function.go`](diffhunk://#diff-89dd96e79be08c01661f02fcd1685672e87e919a8b85cfff85d2a2058f725af3L289-R294): Added a check in the `Run` method to validate names against the `DenyDoubleHyphens` configuration. Implemented a new `validateDoubleHyphens` function to enforce this rule and return an error if double hyphens are detected. [[1]](diffhunk://#diff-89dd96e79be08c01661f02fcd1685672e87e919a8b85cfff85d2a2058f725af3L289-R294) [[2]](diffhunk://#diff-89dd96e79be08c01661f02fcd1685672e87e919a8b85cfff85d2a2058f725af3R315-R323)

### Unit tests for double hyphen validation:
* [`internal/provider/name_function_test.go`](diffhunk://#diff-ed430c5e71dfaf65bc529486833d0b1b8cf277aee8c28dad17c30f4a12abc246R43-R56): Added a new test case, `TestNameFunction_DoubleHyphenError`, to verify that the double hyphen validation correctly identifies invalid names and raises the expected error.

### Configuration default update:
* [`internal/provider/name_function_test.go`](diffhunk://#diff-ed430c5e71dfaf65bc529486833d0b1b8cf277aee8c28dad17c30f4a12abc246L196-R210): Updated the `locals` block in test configuration to set `deny_double_hyphens` to `true` by default, ensuring the validation is active during tests.