### PR TITLE
Feature: add useUpperCase support with conflict detection (#64)

### DIFF
--- a/docs/data-sources/config.md
+++ b/docs/data-sources/config.md
@@ -58,6 +58,7 @@ output "resource_group_name" {
 - `random_seed` (Number) A random seed used by the random number generator. This is used to generate a random name for the naming schema. The default value is 1337. Make sure to update this value to avoid collisions for globally unique names. Will override the random seed defined in the provider settings.
 - `separator` (String) The separator to use for generating the resulting name. Will override the separator defined in the provider settings.
 - `suffixes` (List of String) A list of strings used as suffixes for the resulting name. Each suffix will be used in order and separated by the separator. Default '[]'
+- `uppercase` (Boolean) Control if the resulting name should be upper case. Overrides all schema configurations. Overrides the default uppercase setting defined in the provider settings.
 
 ### Read-Only
 
@@ -78,6 +79,7 @@ Read-Only:
 - `random_seed` (Number)
 - `separator` (String)
 - `suffixes` (List of String)
+- `uppercase` (Boolean)
 
 
 <a id="nestedatt--schema"></a>
@@ -104,3 +106,4 @@ Read-Only:
 - `use_environment` (Boolean)
 - `use_lower_case` (Boolean)
 - `use_separator` (Boolean)
+- `use_upper_case` (Boolean)

--- a/docs/functions/name.md
+++ b/docs/functions/name.md
@@ -96,6 +96,7 @@ Supported keys:
 | `hash_length` | `number` | Length of the random hash segment (0 = disabled). |
 | `random_seed` | `number` | Seed for the hash generator (for reproducible names). |
 | `lowercase` | `bool` | Convert the final name to lowercase. |
+| `uppercase` | `bool` | Convert the final name to uppercase. |
 
 Pass `{}` or `null` to use provider defaults for all settings.
 1. `name` (String) Name to parse

--- a/docs/functions/validate.md
+++ b/docs/functions/validate.md
@@ -117,6 +117,7 @@ Supported keys:
 | `hash_length` | `number` | Length of the random hash segment (0 = disabled). |
 | `random_seed` | `number` | Seed for the hash generator (for reproducible names). |
 | `lowercase` | `bool` | Convert the final name to lowercase. |
+| `uppercase` | `bool` | Convert the final name to uppercase. |
 
 Pass `{}` or `null` to use provider defaults for all settings.
 1. `name` (String) Name to parse

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,7 @@ provider "standesamt" {
 
     The reference is using the [default standesamt library](https://github.com/glueckkanja/standesamt-schema-library). (see [below for nested schema](#nestedatt--schema_reference))
 - `separator` (String) The separator to use for generating the resulting name. Default '-'
+- `uppercase` (Boolean) Control if the resulting name should be upper case. Default 'false'
 
 <a id="nestedatt--schema_reference"></a>
 ### Nested Schema for `schema_reference`

--- a/internal/provider/config_data_resource.go
+++ b/internal/provider/config_data_resource.go
@@ -36,6 +36,7 @@ type configurationModel struct {
 	RandomSeed  types.Int64  `tfsdk:"random_seed"`
 	HashLength  types.Int32  `tfsdk:"hash_length"`
 	Lowercase   types.Bool   `tfsdk:"lowercase"`
+	Uppercase   types.Bool   `tfsdk:"uppercase"`
 	Prefixes    types.List   `tfsdk:"prefixes"`
 	Suffixes    types.List   `tfsdk:"suffixes"`
 	Location    types.String `tfsdk:"location"`
@@ -49,6 +50,7 @@ type schemaDataSourceModel struct {
 	RandomSeed    types.Int64  `tfsdk:"random_seed"`
 	HashLength    types.Int32  `tfsdk:"hash_length"`
 	Lowercase     types.Bool   `tfsdk:"lowercase"`
+	Uppercase     types.Bool   `tfsdk:"uppercase"`
 	Prefixes      types.List   `tfsdk:"prefixes"`
 	Suffixes      types.List   `tfsdk:"suffixes"`
 	Schema        types.Map    `tfsdk:"schema"`
@@ -68,6 +70,7 @@ func configurationTypeAttributes() map[string]attr.Type {
 		"random_seed": types.Int64Type,
 		"hash_length": types.Int32Type,
 		"lowercase":   types.BoolType,
+		"uppercase":   types.BoolType,
 		"prefixes":    types.ListType{ElemType: types.StringType},
 		"suffixes":    types.ListType{ElemType: types.StringType},
 		"location":    types.StringType, //TODO
@@ -113,6 +116,11 @@ func (d *SchemaDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				Optional:            true,
 				Description:         "Control if the resulting name should be lower case. Overrides all schema configurations. Overrides the default lowercase setting defined in the provider settings.",
 				MarkdownDescription: "Control if the resulting name should be lower case. Overrides all schema configurations. Overrides the default lowercase setting defined in the provider settings.",
+			},
+			"uppercase": schema.BoolAttribute{
+				Optional:            true,
+				Description:         "Control if the resulting name should be upper case. Overrides all schema configurations. Overrides the default uppercase setting defined in the provider settings.",
+				MarkdownDescription: "Control if the resulting name should be upper case. Overrides all schema configurations. Overrides the default uppercase setting defined in the provider settings.",
 			},
 			"prefixes": schema.ListAttribute{
 				Optional:            true,
@@ -224,6 +232,11 @@ func (d *SchemaDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	configuration.Lowercase = data.Lowercase
 	if configuration.Lowercase.IsNull() {
 		configuration.Lowercase = d.providerSettings.Lowercase
+	}
+
+	configuration.Uppercase = data.Uppercase
+	if configuration.Uppercase.IsNull() {
+		configuration.Uppercase = d.providerSettings.Uppercase
 	}
 
 	configuration.Environment = data.Environment

--- a/internal/provider/name_builder.go
+++ b/internal/provider/name_builder.go
@@ -111,6 +111,10 @@ func parseSettingsFromDynamic(settingsDynamic types.Dynamic) (*s.BuildNameSettin
 		settings.Lowercase = v.ValueBool()
 	}
 
+	if v, ok := attrs["uppercase"].(types.Bool); ok && !v.IsNull() && !v.IsUnknown() {
+		settings.Uppercase = v.ValueBool()
+	}
+
 	// Handle list/tuple attributes - HCL uses tuples for literal lists
 	if v, ok := attrs["prefixes"]; ok {
 		settings.Prefixes = extractStringSlice(v)
@@ -375,10 +379,25 @@ func (nb *nameBuilder) buildNameComponents(name types.String) {
 	nb.result.Name = types.StringValue(strings.Join(calculatedContent, nb.result.Separator.ValueString()))
 }
 
-// applyLowercase converts the name to lowercase if needed
-func (nb *nameBuilder) applyLowercase() {
-	if nb.typeSchema.Configuration.UseLowerCase.ValueBool() || nb.model.Configuration.Lowercase.ValueBool() || nb.buildNameSettings.Lowercase {
+// applyCasing converts the name to lower or upper case if needed.
+// Returns an error if both lowercase and uppercase are simultaneously requested.
+func (nb *nameBuilder) applyCasing(resp *function.RunResponse) {
+	wantLower := nb.typeSchema.Configuration.UseLowerCase.ValueBool() ||
+		nb.model.Configuration.Lowercase.ValueBool() ||
+		nb.buildNameSettings.Lowercase
+	wantUpper := nb.typeSchema.Configuration.UseUpperCase.ValueBool() ||
+		nb.model.Configuration.Uppercase.ValueBool() ||
+		nb.buildNameSettings.Uppercase
+
+	if wantLower && wantUpper {
+		resp.Error = function.ConcatFuncErrors(resp.Error,
+			function.NewFuncError("Invalid configuration: lowercase and uppercase cannot both be true"))
+		return
+	}
+	if wantLower {
 		nb.result.Name = toLower(nb.result.Name)
+	} else if wantUpper {
+		nb.result.Name = toUpper(nb.result.Name)
 	}
 }
 
@@ -401,7 +420,7 @@ func (nb *nameBuilder) buildName(name types.String, resp *function.RunResponse) 
 		nb.result.Name = name
 	}
 
-	nb.applyLowercase()
+	nb.applyCasing(resp)
 	return nb.result.Name
 }
 

--- a/internal/provider/name_builder_test.go
+++ b/internal/provider/name_builder_test.go
@@ -9,6 +9,7 @@ import (
 	s "terraform-provider-standesamt/internal/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -191,6 +192,75 @@ func TestResolveSeparator(t *testing.T) {
 			nb := makeTestNameBuilder(tt.perCall, tt.schema, tt.provider, tt.useSeparator)
 			nb.resolveSeparator()
 			assert.Equal(t, tt.want, nb.result.Separator.ValueString())
+		})
+	}
+}
+
+func makeTestBuilderForCasing(useLower, useUpper bool) (*nameBuilder, *function.RunResponse) {
+	resp := &function.RunResponse{}
+	nb := &nameBuilder{
+		model: &configurationsModel{
+			Configuration: configurationModel{
+				Lowercase: types.BoolValue(false),
+				Uppercase: types.BoolValue(false),
+			},
+		},
+		typeSchema: &s.NamingSchema{
+			Configuration: s.Configuration{
+				UseLowerCase: types.BoolValue(useLower),
+				UseUpperCase: types.BoolValue(useUpper),
+			},
+		},
+		buildNameSettings: &s.BuildNameSettingsModel{},
+		result: &buildNameResultModel{
+			Name: types.StringValue("RG-MyApp-WE"),
+		},
+	}
+	return nb, resp
+}
+
+func TestApplyCasing(t *testing.T) {
+	tests := []struct {
+		name      string
+		useLower  bool
+		useUpper  bool
+		input     string
+		want      string
+		wantError bool
+	}{
+		{
+			name:     "lowercase applied",
+			useLower: true, useUpper: false,
+			input: "RG-MyApp-WE", want: "rg-myapp-we",
+		},
+		{
+			name:     "uppercase applied",
+			useLower: false, useUpper: true,
+			input: "rg-myapp-we", want: "RG-MYAPP-WE",
+		},
+		{
+			name:     "no casing change",
+			useLower: false, useUpper: false,
+			input: "rg-MyApp-we", want: "rg-MyApp-we",
+		},
+		{
+			name:     "conflict returns error",
+			useLower: true, useUpper: true,
+			input: "rg-myapp-we", wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nb, resp := makeTestBuilderForCasing(tt.useLower, tt.useUpper)
+			nb.result.Name = types.StringValue(tt.input)
+			nb.applyCasing(resp)
+			if tt.wantError {
+				assert.NotNil(t, resp.Error)
+			} else {
+				assert.Nil(t, resp.Error)
+				assert.Equal(t, tt.want, nb.result.Name.ValueString())
+			}
 		})
 	}
 }

--- a/internal/provider/name_function.go
+++ b/internal/provider/name_function.go
@@ -107,7 +107,8 @@ func (f *NameFunction) Definition(_ context.Context, _ function.DefinitionReques
 					"| `name_precedence` | `list(string)` | Order of name segments. |\n" +
 					"| `hash_length` | `number` | Length of the random hash segment (0 = disabled). |\n" +
 					"| `random_seed` | `number` | Seed for the hash generator (for reproducible names). |\n" +
-					"| `lowercase` | `bool` | Convert the final name to lowercase. |\n\n" +
+					"| `lowercase` | `bool` | Convert the final name to lowercase. |\n" +
+					"| `uppercase` | `bool` | Convert the final name to uppercase. |\n\n" +
 					"Pass `{}` or `null` to use provider defaults for all settings.",
 			},
 			function.StringParameter{
@@ -163,4 +164,12 @@ func toLower(s types.String) types.String {
 	}
 
 	return types.StringValue(strings.ToLower(s.ValueString()))
+}
+
+func toUpper(s types.String) types.String {
+	if s.IsNull() || s.IsUnknown() {
+		return s
+	}
+
+	return types.StringValue(strings.ToUpper(s.ValueString()))
 }

--- a/internal/provider/name_function_test.go
+++ b/internal/provider/name_function_test.go
@@ -193,6 +193,125 @@ func TestNameFunction_SchemaSeparatorOverride(t *testing.T) {
 	})
 }
 
+// Config where the schema-level use_upper_case = true converts the result to uppercase.
+const config_with_schema_uppercase = `
+locals {
+	settings = {}
+	config = {
+		configuration = {
+			convention 		= "default"
+			environment 		= ""
+			prefixes 			= []
+			suffixes			= []
+			name_precedence 	= ["abbreviation", "name", "location"]
+			hash_length 		= 0
+			random_seed 		= 1337
+			separator 			= "-"
+			location 			= "westeurope"
+			lowercase 			= false
+			uppercase			= false
+		}
+		schema = {
+			azurerm_resource_group = {
+				resource_type 		= "azurerm_resource_group"
+				abbreviation 		= "rg"
+				min_length 			= 1
+				max_length			= 90
+				validation_regex 	= "^[a-zA-Z0-9-._()]{0,89}[a-zA-Z0-9-_()]$"
+				configuration = {
+				  use_environment		= false
+				  use_lower_case 		= false
+				  use_upper_case		= true
+				  use_separator 		= true
+				  separator			= ""
+				  deny_double_hyphens = false
+				  name_precedence		= []
+				  hash_length			= 0
+				}
+			}
+		}
+		locations = {
+			"westeurope" = "we"
+		}
+	}
+}
+`
+
+// Config where both use_lower_case and use_upper_case are true — must produce an error.
+const config_with_casing_conflict = `
+locals {
+	settings = {}
+	config = {
+		configuration = {
+			convention 		= "default"
+			environment 		= ""
+			prefixes 			= []
+			suffixes			= []
+			name_precedence 	= ["abbreviation", "name", "location"]
+			hash_length 		= 0
+			random_seed 		= 1337
+			separator 			= "-"
+			location 			= "westeurope"
+			lowercase 			= false
+			uppercase			= false
+		}
+		schema = {
+			azurerm_resource_group = {
+				resource_type 		= "azurerm_resource_group"
+				abbreviation 		= "rg"
+				min_length 			= 1
+				max_length			= 90
+				validation_regex 	= "^[a-zA-Z0-9-._()]{0,89}[a-zA-Z0-9-_()]$"
+				configuration = {
+				  use_environment		= false
+				  use_lower_case 		= true
+				  use_upper_case		= true
+				  use_separator 		= true
+				  separator			= ""
+				  deny_double_hyphens = false
+				  name_precedence		= []
+				  hash_length			= 0
+				}
+			}
+		}
+		locations = {
+			"westeurope" = "we"
+		}
+	}
+}
+`
+
+func TestNameFunction_UpperCase(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesUnique(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf("%s %s", config_with_schema_uppercase, `output "test" {
+					value = provider::standesamt::name(local.config, "azurerm_resource_group", local.settings, "myapp")
+				}`),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// use_upper_case = true → "RG-MYAPP-WE"
+					statecheck.ExpectKnownOutputValue("test", knownvalue.StringExact("RG-MYAPP-WE")),
+				},
+			},
+		},
+	})
+}
+
+func TestNameFunction_CasingConflictError(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesUnique(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf("%s %s", config_with_casing_conflict, `output "test" {
+					value = provider::standesamt::name(local.config, "azurerm_resource_group", local.settings, "myapp")
+				}`),
+				ExpectError: regexp.MustCompile(`lowercase and uppercase cannot both be true`),
+			},
+		},
+	})
+}
+
 func TestNameFunction_AzureCaf(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesUnique(),
@@ -289,6 +408,7 @@ random_seed = 1234
 separator = "_"
 location = "westeurope"
 lowercase = true
+uppercase			= false
 `)
 
 var remote_schema_config_with_null_values = fmt.Sprintf(schema_config, `
@@ -302,6 +422,7 @@ random_seed = null
 separator = null
 location = null
 lowercase = null
+uppercase			= false
 `)
 
 var remote_schema_config_with_partial_null_values = fmt.Sprintf(schema_config, `
@@ -315,6 +436,7 @@ random_seed = 1234
 separator = "_"
 location = "westeurope"
 lowercase = true
+uppercase			= false
 `)
 
 const default_config = `
@@ -334,6 +456,7 @@ locals {
 			separator 			= "-"
 			location 			= "westeurope"
 			lowercase 			= true
+			uppercase			= false
 		}
 		schema = {
 			azurerm_resource_group = {
@@ -345,6 +468,7 @@ locals {
 				configuration = {
 				  use_environment		= true
 				  use_lower_case 		= false
+				  use_upper_case		= false
 				  use_separator 		= true
 				  separator			= ""
 				  deny_double_hyphens = true
@@ -378,6 +502,7 @@ locals {
 			separator 			= "-"
 			location 			= "westeurope"
 			lowercase 			= true
+			uppercase			= false
 		}
 		schema = {
 			azurerm_storage_account = {
@@ -389,6 +514,7 @@ locals {
 				configuration = {
 				  use_environment		= false
 				  use_lower_case 		= true
+				  use_upper_case		= false
 				  use_separator 		= false
 				  separator			= ""
 				  deny_double_hyphens = false
@@ -421,6 +547,7 @@ locals {
 			separator 			= "-"
 			location 			= "westeurope"
 			lowercase 			= false
+			uppercase			= false
 		}
 		schema = {
 			azurerm_resource_group = {
@@ -432,6 +559,7 @@ locals {
 				configuration = {
 				  use_environment		= false
 				  use_lower_case 		= false
+				  use_upper_case		= false
 				  use_separator 		= true
 				  separator			= "_"
 				  deny_double_hyphens = false
@@ -463,6 +591,7 @@ locals {
 			separator 			= "-"
 			location 			= "westeurope"
 			lowercase 			= true
+			uppercase			= false
 		}
 		schema = {}
 		locations = {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -67,6 +67,7 @@ type providerData struct {
 	Separator       types.String `tfsdk:"separator"`
 	HashLength      types.Int32  `tfsdk:"hash_length"`
 	Lowercase       types.Bool   `tfsdk:"lowercase"`
+	Uppercase       types.Bool   `tfsdk:"uppercase"`
 	RandomSeed      types.Int64  `tfsdk:"random_seed"`
 	SchemaReference types.Object `tfsdk:"schema_reference"`
 }
@@ -133,6 +134,11 @@ func (p *StandesamtProvider) Schema(_ context.Context, _ provider.SchemaRequest,
 				Optional:            true,
 				Description:         "Control if the resulting name should be lower case. Default 'false'",
 				MarkdownDescription: "Control if the resulting name should be lower case. Default 'false'",
+			},
+			"uppercase": schema.BoolAttribute{
+				Optional:            true,
+				Description:         "Control if the resulting name should be upper case. Default 'false'",
+				MarkdownDescription: "Control if the resulting name should be upper case. Default 'false'",
 			},
 			"schema_reference": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
@@ -219,6 +225,10 @@ func (d *providerData) configProviderFromEnvironment() diag.Diagnostics {
 		d.Lowercase = types.BoolValue(val == "true")
 	}
 
+	if val := os.Getenv("SA_UPPERCASE"); val != "" && d.Uppercase.IsNull() {
+		d.Uppercase = types.BoolValue(val == "true")
+	}
+
 	return nil
 }
 
@@ -245,6 +255,10 @@ func (d *providerData) configProviderDefaults() {
 
 	if d.Lowercase.IsNull() {
 		d.Lowercase = types.BoolValue(false)
+	}
+
+	if d.Uppercase.IsNull() {
+		d.Uppercase = types.BoolValue(false)
 	}
 
 	if d.SchemaReference.IsNull() {

--- a/internal/provider/validate_function.go
+++ b/internal/provider/validate_function.go
@@ -69,7 +69,8 @@ func (f *ValidateFunction) Definition(_ context.Context, _ function.DefinitionRe
 					"| `name_precedence` | `list(string)` | Order of name segments. |\n" +
 					"| `hash_length` | `number` | Length of the random hash segment (0 = disabled). |\n" +
 					"| `random_seed` | `number` | Seed for the hash generator (for reproducible names). |\n" +
-					"| `lowercase` | `bool` | Convert the final name to lowercase. |\n\n" +
+					"| `lowercase` | `bool` | Convert the final name to lowercase. |\n" +
+					"| `uppercase` | `bool` | Convert the final name to uppercase. |\n\n" +
 					"Pass `{}` or `null` to use provider defaults for all settings.",
 			},
 			function.StringParameter{

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -26,6 +26,7 @@ type JsonNamingSchema struct {
 type JsonConfigurationSchema struct {
 	UseEnvironment    bool     `json:"useEnvironment"`
 	UseLowerCase      bool     `json:"useLowerCase"`
+	UseUpperCase      bool     `json:"useUpperCase"`
 	UseSeparator      bool     `json:"useSeparator"`
 	Separator         string   `json:"separator,omitempty"`
 	DenyDoubleHyphens bool     `json:"denyDoubleHyphens"`
@@ -50,6 +51,7 @@ type BuildNameSettingsModel struct {
 	Separator      string
 	Location       string
 	Lowercase      bool
+	Uppercase      bool
 }
 
 type NamingSchemaMap map[string]NamingSchema
@@ -66,6 +68,7 @@ type NamingSchema struct {
 type Configuration struct {
 	UseEnvironment    types.Bool   `tfsdk:"use_environment"`
 	UseLowerCase      types.Bool   `tfsdk:"use_lower_case"`
+	UseUpperCase      types.Bool   `tfsdk:"use_upper_case"`
 	UseSeparator      types.Bool   `tfsdk:"use_separator"`
 	Separator         types.String `tfsdk:"separator"`
 	DenyDoubleHyphens types.Bool   `tfsdk:"deny_double_hyphens"`
@@ -95,6 +98,7 @@ func NewNamingSchemaMap(schemas []JsonNamingSchema) NamingSchemaMap {
 			Configuration: Configuration{
 				UseEnvironment:    types.BoolValue(s.Configuration.UseEnvironment),
 				UseLowerCase:      types.BoolValue(s.Configuration.UseLowerCase),
+				UseUpperCase:      types.BoolValue(s.Configuration.UseUpperCase),
 				UseSeparator:      types.BoolValue(s.Configuration.UseSeparator),
 				Separator:         types.StringValue(s.Configuration.Separator),
 				DenyDoubleHyphens: types.BoolValue(s.Configuration.DenyDoubleHyphens),
@@ -123,6 +127,7 @@ func SchemaTypeAttributes() map[string]attr.Type {
 			AttrTypes: map[string]attr.Type{
 				"use_environment":     types.BoolType,
 				"use_lower_case":      types.BoolType,
+				"use_upper_case":      types.BoolType,
 				"use_separator":       types.BoolType,
 				"separator":           types.StringType,
 				"deny_double_hyphens": types.BoolType,


### PR DESCRIPTION
## Summary

- Adds `useUpperCase` as a mirror of the existing `useLowerCase` at all layers: JSON schema, Terraform type (`use_upper_case`), provider config (`uppercase`), and per-call `settings` object
- Replaces `applyLowercase()` with `applyCasing()` which detects conflicts: if both lower and upper are simultaneously requested from any source (schema, model, or per-call settings), an error is returned
- Adds `SA_UPPERCASE` environment variable following the same pattern as `SA_LOWERCASE`

## Test plan

- [x] Unit tests: `TestApplyCasing` covers lowercase applied, uppercase applied, no casing change, and conflict error
- [x] Integration tests: `TestNameFunction_UpperCase` and `TestNameFunction_CasingConflictError` added
- [x] All existing tests updated with `use_upper_case = false` / `uppercase = false` in inline config blocks
- [x] `go test ./...` passes
- [x] `make lint` passes (0 issues)
- [x] `make generate` regenerates docs

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)